### PR TITLE
7 subscription 관련 설계하기

### DIFF
--- a/src/main/java/hello/squadfit/api/Member/controller/MemberController.java
+++ b/src/main/java/hello/squadfit/api/Member/controller/MemberController.java
@@ -1,8 +1,8 @@
-package hello.squadfit.api.user.controller;
+package hello.squadfit.api.Member.controller;
 
-import hello.squadfit.api.user.request.CreateUserProfileRequest;
-import hello.squadfit.api.user.request.LoginRequest;
-import hello.squadfit.api.user.response.LoginResponse;
+import hello.squadfit.api.Member.request.CreateMemberProfileRequest;
+import hello.squadfit.api.Member.request.LoginRequest;
+import hello.squadfit.api.Member.response.LoginResponse;
 import hello.squadfit.domain.member.entity.Member;
 import hello.squadfit.domain.member.service.UserService;
 import jakarta.validation.Valid;
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/users")
-public class UserController {
+public class MemberController {
 
     private final UserService userService;
 
@@ -33,7 +33,7 @@ public class UserController {
         Member loginMember = userService.login(request);
         LoginResponse result = LoginResponse.builder()
                 .level(loginMember.getLevel())
-                .point(loginMember.getPoint())
+//                .point(loginMember.getPoint())
                 .nickName(loginMember.getNickName())
                 .requiredExperience(loginMember.getRequiredExperience())
                 .availableReportCount(loginMember.getAvailableReportCount())
@@ -42,7 +42,7 @@ public class UserController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<?> register(@Valid @RequestBody CreateUserProfileRequest request, BindingResult bindingResult){
+    public ResponseEntity<?> register(@Valid @RequestBody CreateMemberProfileRequest request, BindingResult bindingResult){
 
         if(bindingResult.hasErrors()){
             log.info("회원가입 오류 = {}", bindingResult);

--- a/src/main/java/hello/squadfit/api/Member/controller/SubscriptionController.java
+++ b/src/main/java/hello/squadfit/api/Member/controller/SubscriptionController.java
@@ -1,0 +1,36 @@
+package hello.squadfit.api.Member.controller;
+
+import hello.squadfit.domain.member.service.SubscriptionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/subscription")
+public class SubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+
+    @PostMapping("/{memberId}")
+    public ResponseEntity<Long> createSubscription(@PathVariable Long memberId){
+        Long subscriptionId = subscriptionService.createSubscription(memberId);
+
+        return ResponseEntity.ok(subscriptionId);
+    }
+
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<String> cancelSubscription(@PathVariable Long memberId){
+        subscriptionService.cancelSubscription(memberId);
+
+        return ResponseEntity.ok("해제성공");
+    }
+
+    @PutMapping("/{memberId}")
+    public ResponseEntity<Long> extendSubscription(@PathVariable Long memberId){
+        Long subscriptionId = subscriptionService.extendSubscription(memberId);
+
+        return ResponseEntity.ok(subscriptionId);
+    }
+
+}

--- a/src/main/java/hello/squadfit/api/Member/request/CreateMemberProfileRequest.java
+++ b/src/main/java/hello/squadfit/api/Member/request/CreateMemberProfileRequest.java
@@ -1,4 +1,4 @@
-package hello.squadfit.api.user.request;
+package hello.squadfit.api.Member.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor
-public class CreateUserProfileRequest {
+public class CreateMemberProfileRequest {
 
     @NotBlank
     private String username;

--- a/src/main/java/hello/squadfit/api/Member/request/LoginRequest.java
+++ b/src/main/java/hello/squadfit/api/Member/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package hello.squadfit.api.user.request;
+package hello.squadfit.api.Member.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;

--- a/src/main/java/hello/squadfit/api/Member/response/AllRecordResponse.java
+++ b/src/main/java/hello/squadfit/api/Member/response/AllRecordResponse.java
@@ -1,4 +1,4 @@
-package hello.squadfit.api.user.response;
+package hello.squadfit.api.Member.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/hello/squadfit/api/Member/response/LoginResponse.java
+++ b/src/main/java/hello/squadfit/api/Member/response/LoginResponse.java
@@ -1,4 +1,4 @@
-package hello.squadfit.api.user.response;
+package hello.squadfit.api.Member.response;
 
 import lombok.*;
 
@@ -10,7 +10,7 @@ public class LoginResponse {
     private String nickName;
     private Integer level;
     private Integer requiredExperience; // 잔여 경험치
-    private Integer point;
+//    private Integer point;
     private Integer availableReportCount; // 레포트 신청 가능한 숫자
 
 }

--- a/src/main/java/hello/squadfit/api/Member/response/SingleRecordResponse.java
+++ b/src/main/java/hello/squadfit/api/Member/response/SingleRecordResponse.java
@@ -1,4 +1,4 @@
-package hello.squadfit.api.user.response;
+package hello.squadfit.api.Member.response;
 
 import hello.squadfit.domain.record.ExerciseCategory;
 import lombok.Builder;

--- a/src/main/java/hello/squadfit/api/record/controller/RecordController.java
+++ b/src/main/java/hello/squadfit/api/record/controller/RecordController.java
@@ -1,15 +1,14 @@
 package hello.squadfit.api.record.controller;
 
 import hello.squadfit.api.record.request.SaveRecordRequest;
-import hello.squadfit.api.user.response.AllRecordResponse;
-import hello.squadfit.api.user.response.SingleRecordResponse;
+import hello.squadfit.api.Member.response.AllRecordResponse;
+import hello.squadfit.api.Member.response.SingleRecordResponse;
 import hello.squadfit.domain.record.service.RecordService;
 import hello.squadfit.domain.member.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/hello/squadfit/domain/member/dto/CreateUserDto.java
+++ b/src/main/java/hello/squadfit/domain/member/dto/CreateUserDto.java
@@ -1,11 +1,11 @@
 package hello.squadfit.domain.member.dto;
 
-import hello.squadfit.domain.member.entity.UserProfile;
+import hello.squadfit.domain.member.entity.MemberProfile;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter @AllArgsConstructor
 public class CreateUserDto {
-    private UserProfile profile;
+    private MemberProfile profile;
     private String nickName;
 }

--- a/src/main/java/hello/squadfit/domain/member/entity/MemberProfile.java
+++ b/src/main/java/hello/squadfit/domain/member/entity/MemberProfile.java
@@ -8,7 +8,7 @@ import lombok.*;
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserProfile {
+public class MemberProfile {
     @Column(nullable = false)
     private String username;
 
@@ -34,7 +34,7 @@ public class UserProfile {
     }
 
     @Builder
-    public UserProfile(String username, String password, String birth, String phone, String name, Role role){
+    public MemberProfile(String username, String password, String birth, String phone, String name, Role role){
         this.username = username;
         this.password = password;
         this.birth = birth;

--- a/src/main/java/hello/squadfit/domain/member/entity/Point.java
+++ b/src/main/java/hello/squadfit/domain/member/entity/Point.java
@@ -1,0 +1,47 @@
+package hello.squadfit.domain.member.entity;
+
+import hello.squadfit.domain.PointConst;
+import jakarta.persistence.*;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+public class Point {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+    private Integer mount;
+
+
+//    /**
+//     * 출석 포인트 증가
+//     */
+//    public void attendancePoint(){
+//        gainExperience(PointConst.ATTENDANCE_POINT);
+//        point += PointConst.ATTENDANCE_POINT;
+//    }
+//
+//    /**
+//     * 운동하기 포인트 증가
+//     */
+//    public void exercisePoint(){
+//        gainExperience(PointConst.EXERCISE_POINT);
+//        point += PointConst.EXERCISE_POINT;
+//    }
+//
+//    /**
+//     * 코멘트 달기 포인트 감소
+//     */
+//    public void requestComment(){
+//        if(point < PointConst.COMMENT_POINT){
+//            throw new IllegalStateException("포인트가 부족하여 코멘트 신청이 불가합니다");
+//        }
+//        point -= PointConst.COMMENT_POINT;
+//    }
+
+}

--- a/src/main/java/hello/squadfit/domain/member/entity/Subscription.java
+++ b/src/main/java/hello/squadfit/domain/member/entity/Subscription.java
@@ -23,6 +23,7 @@ public class Subscription {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private Integer count; // 연장횟수
+    private Long memberId; // 구독 내역 확인을 위한 멤버
 
     // == 연관관계 == //
     @OneToOne(mappedBy = "subscription", fetch = LAZY)
@@ -37,6 +38,7 @@ public class Subscription {
         subscription.endDate = endDate;
         member.linkSubscription(subscription);
         subscription.count = 0;
+        subscription.memberId = member.getId();
         return subscription;
     }
 

--- a/src/main/java/hello/squadfit/domain/member/entity/Subscription.java
+++ b/src/main/java/hello/squadfit/domain/member/entity/Subscription.java
@@ -2,6 +2,7 @@ package hello.squadfit.domain.member.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,19 +19,15 @@ public class Subscription {
     @Column(name = "subscription_id")
     private Long id;
 
-    @OneToOne(fetch = LAZY, cascade = ALL)
-    @JoinColumn(name = "member_id")
-    private Member member;
-
-    private Boolean status;
+    private Boolean status; // 구독 내역을 봐야해서
     private LocalDateTime startDate;
     private LocalDateTime endDate;
+    private Integer count; // 연장횟수
 
-    // == 연관관계 편의 메서드 == //
-    private void setMember(Member member){
-        this.member = member;
-        member.linkSubscription(this);
-    }
+    // == 연관관계 == //
+    @OneToOne(mappedBy = "subscription", fetch = LAZY)
+    private Member member;
+
 
     // == 생성 메서드 == //
     public static Subscription createSubscription(Member member, LocalDateTime startDate, LocalDateTime endDate){
@@ -38,26 +35,35 @@ public class Subscription {
         subscription.status = true;
         subscription.startDate = startDate;
         subscription.endDate = endDate;
-        subscription.setMember(member);
+        member.linkSubscription(subscription);
+        subscription.count = 0;
         return subscription;
     }
 
     // == 비즈니스 로직 == //
+    public void linkedMember(Member member){
+        this.member = member;
+    }
 
     /**
      * 구독 해지
      */
     public void unsubscribe(){
-        if(this.status == null && this.status == false){
+        if(this.status == null || this.status == false){
             throw new IllegalStateException("구독한적이 없습니다.");
         }
         this.status = false;
-        this.startDate = null;
-        this.endDate = null;
     }
 
     /**
      * 구독 연장
      */
+    public void continueSubscription(LocalDateTime endDate){
+        if(this.status == null || this.status == false){
+            throw new IllegalStateException("구독한적이 없습니다.");
+        }
+        this.endDate = endDate;
+        count++;
+    }
 
 }

--- a/src/main/java/hello/squadfit/domain/member/entity/Trainer.java
+++ b/src/main/java/hello/squadfit/domain/member/entity/Trainer.java
@@ -14,13 +14,13 @@ public class Trainer {
     private Long id;
 
     @Embedded
-    private UserProfile profile;
+    private MemberProfile profile;
 
 //    private List<Comment> comments;
 //    private List<Report> reports;
 
     // == 생성 메서드 == //
-    public static Trainer createTrainer(UserProfile profile){
+    public static Trainer createTrainer(MemberProfile profile){
         Trainer trainer = new Trainer();
         trainer.profile = profile;
         return trainer;

--- a/src/main/java/hello/squadfit/domain/member/repository/MemberRepository.java
+++ b/src/main/java/hello/squadfit/domain/member/repository/MemberRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByProfileUsername(String username);
     boolean existsMemberById(Long memberId);

--- a/src/main/java/hello/squadfit/domain/member/repository/SubscriptionRepository.java
+++ b/src/main/java/hello/squadfit/domain/member/repository/SubscriptionRepository.java
@@ -1,0 +1,8 @@
+//package hello.squadfit.domain.member.repository;
+//
+//import hello.squadfit.domain.member.entity.Subscription;
+//import org.springframework.data.jpa.repository.JpaRepository;
+//
+//public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+//}
+// 사용안함

--- a/src/main/java/hello/squadfit/domain/member/service/SubscriptionService.java
+++ b/src/main/java/hello/squadfit/domain/member/service/SubscriptionService.java
@@ -1,0 +1,47 @@
+package hello.squadfit.domain.member.service;
+
+import hello.squadfit.domain.member.entity.Member;
+import hello.squadfit.domain.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SubscriptionService {
+
+    private final MemberRepository memberRepository;
+
+    // 구독하기
+    public Long createSubscription(Long memberId){
+
+        Member findMember = memberRepository.findById(memberId).orElseThrow(() -> new IllegalStateException("사람 없어유"));
+        LocalDateTime startDate = LocalDateTime.now();
+        LocalDateTime endDate = startDate.plusMonths(1);
+
+        Long subscriptionId = findMember.subscribe(startDate, endDate);
+
+        return subscriptionId;
+
+    }
+
+    // 해제하기
+    public void cancelSubscription(Long memberId){
+        Member findMember = memberRepository.findById(memberId).orElseThrow(() -> new IllegalStateException("사람이 맞아요?"));
+        findMember.cancelSubscription();
+    }
+
+    // 연장하기
+    public Long extendSubscription(Long memberId){
+        Member findMember = memberRepository.findById(memberId).orElseThrow(() -> new IllegalStateException("사람이 맞아요?"));
+        LocalDateTime originalEndDate = findMember.getSubscription().getEndDate();
+        LocalDateTime endDate = originalEndDate.plusMonths(1);
+        Long subscriptionId = findMember.extendSubscription(endDate);
+
+        return subscriptionId;
+    }
+
+}

--- a/src/main/java/hello/squadfit/domain/member/service/UserService.java
+++ b/src/main/java/hello/squadfit/domain/member/service/UserService.java
@@ -1,12 +1,12 @@
 package hello.squadfit.domain.member.service;
 
-import hello.squadfit.api.user.request.CreateUserProfileRequest;
-import hello.squadfit.api.user.request.LoginRequest;
+import hello.squadfit.api.Member.request.CreateMemberProfileRequest;
+import hello.squadfit.api.Member.request.LoginRequest;
 import hello.squadfit.domain.member.Role;
 import hello.squadfit.domain.member.dto.CreateUserDto;
 import hello.squadfit.domain.member.entity.Member;
-import hello.squadfit.domain.member.entity.UserProfile;
-import hello.squadfit.domain.member.repository.UserRepository;
+import hello.squadfit.domain.member.entity.MemberProfile;
+import hello.squadfit.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,12 +20,12 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class UserService {
 
-    private final UserRepository userRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
-    public Long register(CreateUserProfileRequest request){
+    public Long register(CreateMemberProfileRequest request){
 
-        UserProfile profile = UserProfile.builder()
+        MemberProfile profile = MemberProfile.builder()
                 .role(Role.Member)
                 .phone(request.getPhone())
                 .name(request.getName())
@@ -34,22 +34,22 @@ public class UserService {
                 .birth(request.getBirth())
                 .build();
 
-        Optional<Member> findUser = userRepository.findByProfileUsername(profile.getUsername());
+        Optional<Member> findUser = memberRepository.findByProfileUsername(profile.getUsername());
         if(!findUser.isEmpty()){
             throw new IllegalStateException("이미 가입되어있는 아이디입니다.");
         }
 
         Member member = Member.createUser(new CreateUserDto(profile, request.getNickName()));
-        Member save = userRepository.save(member);
+        Member save = memberRepository.save(member);
         return save.getId();
     }
 
     public Optional<Member> findOne(Long userId){
-        return userRepository.findById(userId);
+        return memberRepository.findById(userId);
     }
 
     public Member login(LoginRequest loginRequest) {
-        Member findMember = userRepository.findByProfileUsername(loginRequest.getUsername())
+        Member findMember = memberRepository.findByProfileUsername(loginRequest.getUsername())
                 .orElseThrow(() -> new IllegalStateException("존재하지 않는 아이디입니다."));
 
         if(!findMember.getProfile().getPassword().equals(loginRequest.getPassword())){
@@ -63,7 +63,7 @@ public class UserService {
 
     // 유저 존재하는지 확인
     public boolean existsMember(Long userId){
-        return userRepository.existsMemberById(userId);
+        return memberRepository.existsMemberById(userId);
     }
 
 

--- a/src/main/java/hello/squadfit/domain/record/service/RecordService.java
+++ b/src/main/java/hello/squadfit/domain/record/service/RecordService.java
@@ -1,15 +1,15 @@
 package hello.squadfit.domain.record.service;
 
 import hello.squadfit.api.record.request.SaveRecordRequest;
-import hello.squadfit.api.user.response.AllRecordResponse;
-import hello.squadfit.api.user.response.SingleRecordResponse;
+import hello.squadfit.api.Member.response.AllRecordResponse;
+import hello.squadfit.api.Member.response.SingleRecordResponse;
 import hello.squadfit.domain.record.dto.CreateRecordDto;
 import hello.squadfit.domain.record.entity.ExerciseType;
 import hello.squadfit.domain.record.entity.ExerciseRecord;
 import hello.squadfit.domain.record.repository.ExerciseTypeRepository;
 import hello.squadfit.domain.record.repository.RecordRepository;
 import hello.squadfit.domain.member.entity.Member;
-import hello.squadfit.domain.member.repository.UserRepository;
+import hello.squadfit.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,12 +21,12 @@ import java.util.Optional;
 public class RecordService {
 
     private final RecordRepository recordRepository;
-    private final UserRepository userRepository;
+    private final MemberRepository memberRepository;
     private final ExerciseTypeRepository exerciseTypeRepository;
 
     public Long save(SaveRecordRequest request){
 
-        Member member = userRepository.findById(request.getUserId())
+        Member member = memberRepository.findById(request.getUserId())
                 .orElseThrow(() -> new IllegalStateException("유저 맞아?"));
 
         ExerciseType exerciseType = exerciseTypeRepository.findById(request.getExerciseTypeId())

--- a/src/test/java/hello/squadfit/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/hello/squadfit/domain/member/service/MemberServiceTest.java
@@ -1,7 +1,7 @@
 package hello.squadfit.domain.member.service;
 
-import hello.squadfit.api.user.request.CreateUserProfileRequest;
-import hello.squadfit.api.user.request.LoginRequest;
+import hello.squadfit.api.Member.request.CreateMemberProfileRequest;
+import hello.squadfit.api.Member.request.LoginRequest;
 import hello.squadfit.domain.member.entity.Member;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
@@ -22,16 +22,16 @@ class MemberServiceTest {
 
     @Test
     public void register(){
-        CreateUserProfileRequest createUserProfileRequest =
-                new CreateUserProfileRequest(
+        CreateMemberProfileRequest createMemberProfileRequest =
+                new CreateMemberProfileRequest(
                         "test","1234","991111"
                         ,"010-1234-5678","jaewoo","yang");
 
-        Long userId = userService.register(createUserProfileRequest);
+        Long userId = userService.register(createMemberProfileRequest);
         Optional<Member> user = userService.findOne(userId);
         Member findMember = user.orElse(null);
 
-        assertThat(findMember.getNickName()).isEqualTo(createUserProfileRequest.getNickName());
+        assertThat(findMember.getNickName()).isEqualTo(createMemberProfileRequest.getNickName());
 
     }
 


### PR DESCRIPTION
엔티티 설계
멤버와의 연관관계 편의 메서드 작성
멤버가 FK주인
멤버를 이용해서 구독 엔티티를 만들고 수정하기 때문에 repository 생성 안함
현재 결제 내역을 확인 할 수 없기 때문에 구독 내역을 DB에 저장해놓음
subscription의 memberId 필드는 내역 조회용으로 만들어놓음